### PR TITLE
fix: fall back to github.token when REPOSITORY_PUSH_TOKEN is unset

### DIFF
--- a/.github/workflows/olm-stable.yaml
+++ b/.github/workflows/olm-stable.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           ref: ${{ steps.branch.outputs.name }}
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -51,7 +51,7 @@ jobs:
 
       - name: Open catalog PR
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
           persist-credentials: false
 
       # standard-version's release-as relies on controller-gen for code generation.
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -100,7 +100,7 @@ jobs:
 
       - name: Open catalog PR
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       # Bumping the version in the next step will also run code generation scripts
       # that depend on controller-gen.
@@ -60,7 +60,7 @@ jobs:
 
       - name: Open catalog PR
         env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io


### PR DESCRIPTION
actions/checkout@v6 now fails hard when passed an empty token string rather than silently falling back to GITHUB_TOKEN. Use the || operator to fall back to github.token when REPOSITORY_PUSH_TOKEN is not defined.