### PR TITLE
fix: use github.token instead of REPOSITORY_PUSH_TOKEN in release wor…

### DIFF
--- a/.github/workflows/olm-stable.yaml
+++ b/.github/workflows/olm-stable.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           ref: ${{ steps.branch.outputs.name }}
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -50,8 +49,6 @@ jobs:
           quay_token: ${{ secrets.QUAY_TOKEN }}
 
       - name: Open catalog PR
-        env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
-          persist-credentials: false
 
       # standard-version's release-as relies on controller-gen for code generation.
       - name: Setup Go environment
@@ -72,7 +70,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       - name: Setup Go environment
         uses: actions/setup-go@v6
@@ -99,8 +96,6 @@ jobs:
           quay_token: ${{ secrets.QUAY_TOKEN }}
 
       - name: Open catalog PR
-        env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
 
       # Bumping the version in the next step will also run code generation scripts
       # that depend on controller-gen.
@@ -59,8 +58,6 @@ jobs:
           quay_token: ${{ secrets.QUAY_TOKEN }}
 
       - name: Open catalog PR
-        env:
-          GH_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN || github.token }}
         run: |
           git config user.name rhobs-release-bot
           git config user.email release-bot@monitoring.rhobs.io


### PR DESCRIPTION
…kflows

The PR-based catalog workflow does not need a PAT. The built-in github.token is sufficient since the workflows already declare contents: write and pull-requests: write permissions.

Remove explicit token: and GH_TOKEN overrides so that actions/checkout uses the default GITHUB_TOKEN (avoiding failures when REPOSITORY_PUSH_TOKEN is unset or stale in forks), and gh pr create picks up GITHUB_TOKEN automatically.

Also drop persist-credentials: false from create-github-prerelease which would have broken git push --follow-tags without a separately configured credential.